### PR TITLE
adds an explicit namespace to the android/build.gradle of the plugin.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.jumio.jumiomobilesdk'
     compileSdk 35
 
     sourceSets {


### PR DESCRIPTION
Starting with Android Gradle Plugin 8.0, every Android module must declare a namespace in its build.gradle file. Without it, the build fails with the error:

```
Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
Namespace not specified. Specify a namespace in the module's build file.
```

Added namespace "com.jumio.mobile.sdk.flutter" (matching the existing manifest package) to resolve the issue.

https://developer.android.com/build/configure-app-module#set-namespace